### PR TITLE
Fixed the on/off toggle state

### DIFF
--- a/index.js
+++ b/index.js
@@ -445,10 +445,11 @@ ZiggoAccessory.prototype = {
   },
 
   setPowerState(state, callback) {
-	this.log('Power on/off');
-	mqttClient.publish(mqttUsername + '/' + setopboxId, '{"id":"' + makeId(8) + '","type":"CPE.KeyEvent","source":"' + varClientId + '","status":{"w3cKey":"Power","eventType":"keyDownUp"}}');
-	currentState = (currentState ? false : true);
-
+    this.log('Power on/off');
+    if (state != currentState) {
+      mqttClient.publish(mqttUsername + '/' + setopboxId, '{"id":"' + makeId(8) + '","type":"CPE.KeyEvent","source":"' + varClientId + '","status":{"w3cKey":"Power","eventType":"keyDownUp"}}');
+      currentState = (currentState ? false : true);
+    }
     callback();
   },
 


### PR DESCRIPTION
The plugin now checks if the system is already on or off, before toggling it. So if it's already on, it won't try to turn it on again.